### PR TITLE
Cambios para utilizar el correo en vez del nombre de usuario

### DIFF
--- a/src/main/java/us/cloud/teachme/auth_service/config/SecurityConfig.java
+++ b/src/main/java/us/cloud/teachme/auth_service/config/SecurityConfig.java
@@ -23,8 +23,8 @@ public class SecurityConfig {
       .authorizeHttpRequests(authorize -> authorize
         .requestMatchers("/api/v1/auth/**").permitAll()
         .requestMatchers("/api/v1/auth/validate").authenticated()
-        .requestMatchers(HttpMethod.POST, "/api/v1/user").permitAll()
-        .requestMatchers("/api/v1/user/**").authenticated()
+        .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
+        .requestMatchers("/api/v1/users/**").authenticated()
         .requestMatchers("/v3/api-docs/**").permitAll()
         .requestMatchers("/swagger-ui/**").permitAll()
         .anyRequest().denyAll()

--- a/src/main/java/us/cloud/teachme/auth_service/controller/AuthController.java
+++ b/src/main/java/us/cloud/teachme/auth_service/controller/AuthController.java
@@ -2,6 +2,7 @@ package us.cloud.teachme.auth_service.controller;
 
 import java.util.Map;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -47,13 +48,13 @@ public class AuthController {
   }
 
   @PostMapping("/register")
-  @Operation(summary = "Register", description = "Register to teachme platform")
+  @Operation(summary = "Register", description = "Register to teachme platform, not implemented yet")
   @ApiResponses(value = {
     @ApiResponse(responseCode = "204", description = "Register successful"),
     @ApiResponse(responseCode = "400", description = "Username already exists")
   })
   public ResponseEntity<Void> register(@RequestBody UserDto user) {
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
   }
 
   @GetMapping("/validate")

--- a/src/main/java/us/cloud/teachme/auth_service/controller/AuthController.java
+++ b/src/main/java/us/cloud/teachme/auth_service/controller/AuthController.java
@@ -18,8 +18,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
+import us.cloud.teachme.auth_service.model.RegisterRequest;
+import us.cloud.teachme.auth_service.model.SignInRequest;
 import us.cloud.teachme.auth_service.model.User;
-import us.cloud.teachme.auth_service.model.UserDto;
 import us.cloud.teachme.auth_service.service.JwtService;
 import us.cloud.teachme.auth_service.service.UserService;
 
@@ -39,9 +40,9 @@ public class AuthController {
     @ApiResponse(responseCode = "200", description = "Sign in successful"),
     @ApiResponse(responseCode = "400", description = "Invalid username or password")
   })
-  public ResponseEntity<?> signin(@RequestBody UserDto userDto) {
-    User user = userService.findUserByUsername(userDto.username());
-    if(!passwordEncoder.matches(userDto.password(), user.getPassword())) {
+  public ResponseEntity<?> signin(@RequestBody SignInRequest signInRequest) {
+    User user = userService.findUserByEmail(signInRequest.email());
+    if(!passwordEncoder.matches(signInRequest.password(), user.getPassword())) {
       return ResponseEntity.badRequest().body(Map.of("error", "Invalid username or password"));
     }
     return ResponseEntity.ok(Map.of("token", jwtService.generateToken(user.getId())));
@@ -53,7 +54,7 @@ public class AuthController {
     @ApiResponse(responseCode = "204", description = "Register successful"),
     @ApiResponse(responseCode = "400", description = "Username already exists")
   })
-  public ResponseEntity<Void> register(@RequestBody UserDto user) {
+  public ResponseEntity<Void> register(@RequestBody RegisterRequest registerRequest) {
     return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
   }
 

--- a/src/main/java/us/cloud/teachme/auth_service/controller/UserController.java
+++ b/src/main/java/us/cloud/teachme/auth_service/controller/UserController.java
@@ -30,7 +30,7 @@ import us.cloud.teachme.auth_service.service.UserService;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("/api/v1/user")
+@RequestMapping("/api/v1/users")
 @Tag(name = "User Management", description = "API for managing users in teachme")
 public class UserController {
 

--- a/src/main/java/us/cloud/teachme/auth_service/controller/UserController.java
+++ b/src/main/java/us/cloud/teachme/auth_service/controller/UserController.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
+import us.cloud.teachme.auth_service.model.SignInRequest;
 import us.cloud.teachme.auth_service.model.User;
-import us.cloud.teachme.auth_service.model.UserDto;
 import us.cloud.teachme.auth_service.model.UserValidator;
 import us.cloud.teachme.auth_service.service.UserService;
 
@@ -66,8 +66,8 @@ public class UserController {
     @ApiResponse(responseCode = "200", description = "User created"),
     @ApiResponse(responseCode = "400", description = "Invalid user")
   })
-  public ResponseEntity<?> createUser(@Validated @RequestBody UserDto userDto) {
-    User user = User.builder().username(userDto.username()).password(userDto.password()).build();
+  public ResponseEntity<?> createUser(@Validated @RequestBody SignInRequest signInRequest) {
+    User user = User.builder().email(signInRequest.email()).password(signInRequest.password()).build();
     Errors errors = userValidator.validateObject(user);
     if(errors.hasErrors()) {
       return ResponseEntity.badRequest().body(errors.getAllErrors());

--- a/src/main/java/us/cloud/teachme/auth_service/controller/UserController.java
+++ b/src/main/java/us/cloud/teachme/auth_service/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
   }
 
   @GetMapping("/{userId}")
-  @Operation(summary = "Get user by id", description = "Get user by id from teachme platform")
+  @Operation(summary = "Get user by id", description = "Get user by id from teachme platform", security = { @SecurityRequirement(name = "bearer-key") })
   @ApiResponses(value = {
     @ApiResponse(responseCode = "200", description = "User found"),
     @ApiResponse(responseCode = "404", description = "User not found")

--- a/src/main/java/us/cloud/teachme/auth_service/model/RegisterRequest.java
+++ b/src/main/java/us/cloud/teachme/auth_service/model/RegisterRequest.java
@@ -1,0 +1,7 @@
+package us.cloud.teachme.auth_service.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RegisterRequest(@Schema(description = "Email of the user account", example = "john.doe@gmail.com") String email, @Schema(description = "Password of the user account", example = "P@ssw0rd") String password) {
+  
+}

--- a/src/main/java/us/cloud/teachme/auth_service/model/SignInRequest.java
+++ b/src/main/java/us/cloud/teachme/auth_service/model/SignInRequest.java
@@ -1,0 +1,7 @@
+package us.cloud.teachme.auth_service.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SignInRequest(@Schema(description = "Email of the user account", example = "john.doe@gmail.com") String email, @Schema(description = "Password of the user account", example = "P@ssw0rd") String password) {
+  
+}

--- a/src/main/java/us/cloud/teachme/auth_service/model/User.java
+++ b/src/main/java/us/cloud/teachme/auth_service/model/User.java
@@ -5,10 +5,10 @@ import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -19,51 +19,31 @@ import lombok.Data;
 @Data
 @Builder
 @Document(collection = "User")
-public class User implements UserDetails {
+public class User {
   
   @Id
   private String id;
 
-  @Schema(description = "Username of the user", example = "john.doe")
-  private String username;
-  
+  @Indexed(unique = true)
+  @Schema(description = "Email of the user", example = "john.doe@gmail.com")
+  private String email;
+
   @Schema(description = "Password of the user", example = "P@ssw0rd")
   private String password;
 
   @Schema(description = "Role of the user", example = "USER | ADMIN")
   private String role;
 
-  @Override
   @JsonIgnore
   public String getPassword() {
     return password;
   }
 
-  @Override
   @Transient
   public Collection<? extends GrantedAuthority> getAuthorities() {
     return List.of(new SimpleGrantedAuthority(role));
   }
 
-  @Override
-  @Transient
-  public boolean isAccountNonExpired() {
-    return true;
-  }
-
-  @Override
-  @Transient
-  public boolean isAccountNonLocked() {
-    return true;
-  }
-
-  @Override
-  @Transient
-  public boolean isCredentialsNonExpired() {
-    return true;
-  }
-
-  @Override
   @Schema(name = "enabled", description = "Is the user account enabled", example = "true")
   public boolean isEnabled() {
     return true;

--- a/src/main/java/us/cloud/teachme/auth_service/model/UserDto.java
+++ b/src/main/java/us/cloud/teachme/auth_service/model/UserDto.java
@@ -1,7 +1,0 @@
-package us.cloud.teachme.auth_service.model;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-
-public record UserDto(@Schema(description = "Username of the user account", example = "john.doe") String username, @Schema(description = "Password of the user account", example = "P@ssw0rd") String password) {
-  
-}

--- a/src/main/java/us/cloud/teachme/auth_service/model/UserValidator.java
+++ b/src/main/java/us/cloud/teachme/auth_service/model/UserValidator.java
@@ -15,10 +15,13 @@ public class UserValidator implements Validator {
 
   @Override
   public void validate(Object target, Errors errors) {
-    ValidationUtils.rejectIfEmpty(errors, "username", "username.empty", "The username can't be null");
+    ValidationUtils.rejectIfEmpty(errors, "email", "email.empty", "The email can't be null");
     User user = (User) target;
-    if(user.getUsername().length() < 3 || user.getUsername().length() > 20) {
-      errors.rejectValue("username", "username.length", "The username length must be between 3 and 20 characters");
+    if(user.getEmail().length() <= 3 || user.getEmail().length() > 30) {
+      errors.rejectValue("email", "email.length", "The email length must be between 4 and 30 characters");
+    }
+    if(!user.getEmail().matches("^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$")) {
+      errors.rejectValue("email", "email.invalid", "The email is invalid");
     }
   }
   

--- a/src/main/java/us/cloud/teachme/auth_service/repository/UserRepository.java
+++ b/src/main/java/us/cloud/teachme/auth_service/repository/UserRepository.java
@@ -9,6 +9,6 @@ import us.cloud.teachme.auth_service.model.User;
 
 public interface UserRepository extends MongoRepository<User, String>{
 
-  List<User> findByUsername(String username);
+  List<User> findByEmail(String email);
   
 }

--- a/src/main/java/us/cloud/teachme/auth_service/service/JwtService.java
+++ b/src/main/java/us/cloud/teachme/auth_service/service/JwtService.java
@@ -17,10 +17,10 @@ import lombok.Data;
 @Service
 public class JwtService {
 
-  @Value("${security.jwt.secret-key}")
+  @Value("${jwt.secret-key}")
   private String SECRET_KEY;
 
-  @Value("${security.jwt.expiration-time}")
+  @Value("${jwt.expiration-time}")
   private long EXPIRATION_TIME;
 
   public String generateToken(String userId) {

--- a/src/main/java/us/cloud/teachme/auth_service/service/UserService.java
+++ b/src/main/java/us/cloud/teachme/auth_service/service/UserService.java
@@ -27,12 +27,12 @@ public class UserService {
     return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
   }
 
-  public User findUserByUsername(String username) {
-    return userRepository.findByUsername(username).stream().findFirst().orElseThrow(UserNotFoundException::new);
+  public User findUserByEmail(String email) {
+    return userRepository.findByEmail(email).stream().findFirst().orElseThrow(UserNotFoundException::new);
   }
 
   public User createUser(User user) {
-    if(!userRepository.findByUsername(user.getUsername()).isEmpty()) {
+    if(!userRepository.findByEmail(user.getEmail()).isEmpty()) {
       throw new UserAlreadyExistsException();
     }
     user.setPassword(passwordEncoder.encode(user.getPassword()));

--- a/src/main/resources/security.properties
+++ b/src/main/resources/security.properties
@@ -1,2 +1,2 @@
-security.jwt.secret-key=${SECRET_KEY}
-security.jwt.expiration-time=3600000
+jwt.secret-key=${SECRET_KEY}
+jwt.expiration-time=3600000

--- a/src/test/resources/rest.http
+++ b/src/test/resources/rest.http
@@ -6,7 +6,7 @@
 @content-type = application/json
 
 @userId = {{me.response.body.id}}
-@username = Prueba
+@email = Prueba@gmail.com
 @password = 123456
 @token = {{signin.response.body.token}}
 
@@ -24,8 +24,8 @@ POST {{baseurl}}/auth/signin HTTP/1.1
 Content-Type: {{content-type}}
 
 {
-    "username": "Prueba",
-    "password": "123456"
+    "email": {{email}},
+    "password": {{password}}
 }
 
 
@@ -36,8 +36,8 @@ POST {{baseurl}}/auth/register HTTP/1.1
 Content-Type: {{content-type}}
 
 {
-    "username": "Prueba",
-    "password": "123456"
+    "username": {{email}},
+    "password": {{password}}
 }
 
 ###
@@ -62,8 +62,8 @@ POST {{baseurl}}/user HTTP/1.1
 Content-Type: {{content-type}}
 
 {
-    "username": "Prueba",
-    "password": "123456"
+    "email": {{email}},
+    "password": {{password}}
 }
 
 ###


### PR DESCRIPTION
Esta pull request incluye cambios en el módulo `auth_service`, centrados en reemplazar el uso de `username` por `email` para la identificación y autenticación de usuarios. Además, introduce nuevos modelos de petición y actualiza varias configuraciones y controladores para reflejar estos cambios.

### Principales cambios:

#### Autenticación y gestión de usuarios:
* Actualizado `SecurityConfig` para cambiar los matchers de petición para los endpoints de usuario de `/api/v1/user` a `/api/v1/users`.
* Sustitución de `UserDto` por `SignInRequest` y `RegisterRequest` en `AuthController` y `UserController`.
* Cambiada la identificación de usuario de `username` a `email` en `User`, `UserValidator`, y `UserRepository`.

#### Modelos:
* Introducidos nuevos modelos `RegisterRequest` y `SignInRequest` para encapsular los datos de registro e inicio de sesión.
* Se ha eliminado el modelo `UserDto` porque ya no es necesario.

#### Configuración:
* Actualizadas las propiedades de configuración JWT en `JwtService` y `security.properties`.

#### Pruebas:
* Actualizados los recursos de prueba para reflejar el cambio de `username` a `email` en las peticiones de autenticación.